### PR TITLE
Add named key support

### DIFF
--- a/src/main/kotlin/io/github/mishkun/ataman/AtamanConfig.kt
+++ b/src/main/kotlin/io/github/mishkun/ataman/AtamanConfig.kt
@@ -118,11 +118,27 @@ private fun KeyStrokeMap.get(char: Char, isLeafBinding: Boolean): KeyStroke {
     )
 }
 
+private val specialKeys = mapOf(
+    "SPACE" to KeyEvent.VK_SPACE,
+    "ENTER" to KeyEvent.VK_ENTER,
+    "TAB" to KeyEvent.VK_TAB,
+    "ESC" to KeyEvent.VK_ESCAPE,
+    "ESCAPE" to KeyEvent.VK_ESCAPE,
+    "BACKSPACE" to KeyEvent.VK_BACK_SPACE,
+)
+
 fun getKeyStroke(key: String, isLeafBinding: Boolean = false): KeyStroke {
     val trimmedKey = key.trim('"')
-    return when (trimmedKey.length) {
-        1 -> keyStrokeMap.get(trimmedKey[0], isLeafBinding)
-        else -> getFKeyStroke(key, isLeafBinding)
+    val upperKey = trimmedKey.uppercase()
+    return when {
+        specialKeys.containsKey(upperKey) -> KeyStroke.getKeyStroke(
+            specialKeys.getValue(upperKey),
+            0,
+            isLeafBinding
+        )
+        trimmedKey.length == 1 -> keyStrokeMap.get(trimmedKey[0], isLeafBinding)
+        upperKey.matches(Regex("F\\d+")) -> getFKeyStroke(upperKey, isLeafBinding)
+        else -> throw IllegalStateException("Unknown key: $key")
     }
 }
 

--- a/src/test/kotlin/io/github/mishkun/ataman/AtamanConfigParsingTest.kt
+++ b/src/test/kotlin/io/github/mishkun/ataman/AtamanConfigParsingTest.kt
@@ -57,6 +57,50 @@ class AtamanConfigParsingTest {
     }
 
     @Test
+    fun `supports named keys`() {
+        val parsedBindings = parseConfig(
+            configDir = tmpFolder.setupStubConfigDir(
+                text = """
+                |bindings {
+                |  SPACE { actionId: CommentByLineComment, description: Comment }
+                |  ENTER { actionId: CommentByLineComment, description: Comment }
+                |}""".trimMargin(),
+            ),
+            ideProductKey = "IC",
+        )
+        assertThat(parsedBindings.exceptionOrNull(), Matchers.nullValue())
+
+        val bindings = parsedBindings.getOrNull()!!
+
+        assertThat(
+            bindings, Matchers.equalTo(
+                listOf(
+                    LeaderBinding.SingleBinding(
+                        KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0, true),
+                        "SPACE",
+                        "Comment",
+                        "CommentByLineComment",
+                    ),
+                    LeaderBinding.SingleBinding(
+                        KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0, true),
+                        "ENTER",
+                        "Comment",
+                        "CommentByLineComment",
+                    ),
+                )
+            )
+        )
+
+        bindings.forEach {
+            assertThat(
+                "Leaf binding should use key release event",
+                (it as LeaderBinding.SingleBinding).key.isOnKeyRelease,
+                Matchers.equalTo(true)
+            )
+        }
+    }
+
+    @Test
     fun `supports multibindings`() {
         val parsedBindings = parseConfig(
             configDir = tmpFolder.setupStubConfigDir(


### PR DESCRIPTION
## Summary
- allow config entries like `SPACE` and `ENTER`
- test named key parsing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848c118aa248330bb0101d11d77ed13